### PR TITLE
upgrade list-extra

### DIFF
--- a/demo/elm-package.json
+++ b/demo/elm-package.json
@@ -10,7 +10,6 @@
     "exposed-modules": [],
     "dependencies": {
         "abadi199/dateparser": "1.0.0 <= v < 2.0.0",
-        "elm-community/list-extra": "4.0.0 <= v < 5.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/svg": "2.0.0 <= v < 3.0.0",

--- a/elm-package.json
+++ b/elm-package.json
@@ -13,7 +13,6 @@
     ],
     "dependencies": {
         "abadi199/dateparser": "1.0.0 <= v < 2.0.0",
-        "elm-community/list-extra": "4.0.0 <= v < 7.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/svg": "2.0.0 <= v < 3.0.0",

--- a/src/DateTimePicker.elm
+++ b/src/DateTimePicker.elm
@@ -47,7 +47,6 @@ import DateTimePicker.Svg
 import Html exposing (Html, button, div, input, li, span, table, tbody, td, text, th, thead, tr, ul)
 import Html.Attributes exposing (value)
 import Html.Events exposing (onBlur, onClick, onFocus)
-import List.Extra
 import String
 import Task
 import Time
@@ -885,10 +884,7 @@ calendar pickerType state currentDate =
 
                         body =
                             tbody [ class [ Days ] ]
-                                (days
-                                    |> List.Extra.groupsOf 7
-                                    |> List.map toWeekRow
-                                )
+                                (List.map toWeekRow days)
                     in
                     table [ class [ Calendar ] ]
                         [ header
@@ -922,9 +918,12 @@ dayNames config =
         shiftAmount =
             DateTimePicker.DateUtils.dayToInt Date.Sun config.firstDayOfWeek
     in
-    days
-        |> List.Extra.splitAt shiftAmount
-        |> (\( head, tail ) -> tail ++ head)
+    rotate shiftAmount days
+
+
+rotate : Int -> List a -> List a
+rotate n xs =
+    List.drop n xs ++ List.take n xs
 
 
 

--- a/src/DateTimePicker/DateUtils.elm
+++ b/src/DateTimePicker/DateUtils.elm
@@ -89,7 +89,7 @@ type MonthType
     | Next
 
 
-generateCalendar : Date.Day -> Date.Month -> Int -> List Day
+generateCalendar : Date.Day -> Date.Month -> Int -> List (List Day)
 generateCalendar firstDayOfWeek month year =
     let
         firstDateOfMonth =
@@ -121,7 +121,19 @@ generateCalendar firstDayOfWeek month year =
             List.range 1 14
                 |> List.map (Day Next)
     in
-    List.take 42 <| previousMonth ++ currentMonth ++ nextMonth
+    previousMonth
+        ++ currentMonth
+        ++ nextMonth
+        |> List.take 42
+        |> byWeek
+
+
+byWeek : List Day -> List (List Day)
+byWeek list =
+    if List.length list >= 7 then
+        List.take 7 list :: byWeek (List.drop 7 list)
+    else
+        []
 
 
 toDateTime : Int -> Date.Month -> Day -> Int -> Int -> Date.Date

--- a/tests/DateUtilsTests.elm
+++ b/tests/DateUtilsTests.elm
@@ -63,15 +63,23 @@ generateCalendarTest =
         [ test "generateCalendar for February 2016 (leap) should return a list of date" <|
             \() ->
                 DateUtils.generateCalendar Date.Sun Date.Feb 2016
-                    |> Expect.equal ([ previous 31 ] ++ (List.range 1 29 |> List.map current) ++ (List.range 1 12 |> List.map next))
+                    |> expectDaysAndShape ([ previous 31 ] ++ (List.range 1 29 |> List.map current) ++ (List.range 1 12 |> List.map next))
         , test "generateCalendar for February 2015 should return a list of date" <|
             \() ->
                 DateUtils.generateCalendar Date.Sun Date.Feb 2015
-                    |> Expect.equal ((List.range 25 31 |> List.map previous) ++ (List.range 1 28 |> List.map current) ++ (List.range 1 7 |> List.map next))
+                    |> expectDaysAndShape ((List.range 25 31 |> List.map previous) ++ (List.range 1 28 |> List.map current) ++ (List.range 1 7 |> List.map next))
         , test "generateCalendar for January 2099 should return a list of date" <|
             \() ->
                 DateUtils.generateCalendar Date.Sun Date.Jan 2099
-                    |> Expect.equal ((List.range 28 31 |> List.map previous) ++ (List.range 1 31 |> List.map current) ++ (List.range 1 7 |> List.map next))
+                    |> expectDaysAndShape ((List.range 28 31 |> List.map previous) ++ (List.range 1 31 |> List.map current) ++ (List.range 1 7 |> List.map next))
+        ]
+
+
+expectDaysAndShape : List DateUtils.Day -> List (List DateUtils.Day) -> Expect.Expectation
+expectDaysAndShape days =
+    Expect.all
+        [ List.concat >> Expect.equal days
+        , List.map List.length >> Expect.equal [ 7, 7, 7, 7, 7, 7 ]
         ]
 
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -12,7 +12,6 @@
         "abadi199/dateparser": "1.0.0 <= v < 2.0.0",
         "eeue56/elm-html-test": "5.0.1 <= v < 6.0.0",
         "elm-community/elm-test": "4.1.1 <= v < 5.0.0",
-        "elm-community/list-extra": "4.0.0 <= v < 7.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/svg": "2.0.0 <= v < 3.0.0",


### PR DESCRIPTION
Nothing changed regarding the functions we use in here.

```
Comparing elm-community/list-extra 4.0.0 to 7.0.1...
This is a MAJOR change.

------ Changes to module List.Extra - MAJOR ------

    Added:
        cartesianProduct : List (List a) -> List (List a)
        count : (a -> Bool) -> List a -> Int
        cycle : Int -> List a -> List a
        initialize : Int -> (Int -> a) -> List a
        removeIfIndex : (Int -> Bool) -> List a -> List a
        reverseMap : (a -> b) -> List a -> List b
        splitWhen : (a -> Bool) -> List a -> Maybe.Maybe (List a, List a)

    Removed:
        singleton : a -> List a

    Changed:
      - andMap : List (a -> b) -> List a -> List b
      + andMap : List a -> List (a -> b) -> List b

      - setAt : Int -> a -> List a -> Maybe.Maybe (List a)
      + setAt : Int -> a -> List a -> List a

      - swapAt : Int -> Int -> List a -> Maybe.Maybe (List a)
      + swapAt : Int -> Int -> List a -> List a

      - updateAt : Int -> (a -> a) -> List a -> Maybe.Maybe (List a)
      + updateAt : Int -> (a -> a) -> List a -> List a
```


we use:
```
src/DateTimePicker.elm|889 col 40| |> List.Extra.groupsOf 7
src/DateTimePicker.elm|926 col 12| |> List.Extra.splitAt shiftAmount
```
