### PR TITLE
allow for elm-css 14

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -16,7 +16,7 @@
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/svg": "2.0.0 <= v < 3.0.0",
         "rluiten/elm-date-extra": "8.1.2 <= v < 9.0.0",
-        "rtfeldman/elm-css": "13.1.1 <= v < 14.0.0"
+        "rtfeldman/elm-css": "13.1.1 <= v < 15.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
elm-css 14.0.0 has been released. I don't believe it changes anything that affects this package, so 13 and 14 should both be valid options.

see: https://github.com/rtfeldman/elm-css/blob/master/CHANGELOG.md

changes in 14 don't affect this package's consumption of the library