### PR TITLE
pad zeros on the formatters

### DIFF
--- a/src/DateTimePicker.elm
+++ b/src/DateTimePicker.elm
@@ -907,7 +907,7 @@ calendar pickerType state currentDate =
                         matchesDay reference day =
                             let
                                 date =
-                                    DateTime.fromDate year month day.day
+                                    DateTimePicker.DateUtils.dayToDateTime year month day
                             in
                             reference
                                 |> Maybe.map
@@ -921,7 +921,7 @@ calendar pickerType state currentDate =
                         isInRange day =
                             let
                                 date =
-                                    DateTime.fromDate year month day
+                                    DateTimePicker.DateUtils.dayToDateTime year month day
                             in
                             case config.earliestDate of
                                 Nothing ->
@@ -935,7 +935,7 @@ calendar pickerType state currentDate =
                         toCell day =
                             let
                                 selectedDate =
-                                    DateTime.fromDate year month day.day
+                                    DateTimePicker.DateUtils.dayToDateTime year month day
 
                                 styles =
                                     List.concat
@@ -948,7 +948,7 @@ calendar pickerType state currentDate =
 
                                             DateTimePicker.DateUtils.Next ->
                                                 [ color Styles.fadeText ]
-                                        , if isInRange day.day then
+                                        , if isInRange day then
                                             []
                                           else
                                             [ backgroundColor inherit
@@ -976,7 +976,7 @@ calendar pickerType state currentDate =
                                     dateClickHandler pickerType stateValue year month day
 
                                 handlers =
-                                    if isInRange day.day then
+                                    if isInRange day then
                                         [ onMouseDownPreventDefault handler
                                         , onTouchStartPreventDefault handler
                                         ]

--- a/src/DateTimePicker/DateUtils.elm
+++ b/src/DateTimePicker/DateUtils.elm
@@ -2,6 +2,7 @@ module DateTimePicker.DateUtils
     exposing
         ( Day
         , MonthType(..)
+        , dayToDateTime
         , dayToInt
         , fromMillitaryAmPm
         , fromMillitaryHour
@@ -82,6 +83,29 @@ type MonthType
     = Previous
     | Current
     | Next
+
+
+dayToDateTime : Int -> Date.Month -> Day -> DateTime.DateTime
+dayToDateTime year month day =
+    case day.monthType of
+        Current ->
+            DateTime.fromDate year month day.day
+
+        Previous ->
+            let
+                previousMonth =
+                    DateTime.fromDate year month day.day
+                        |> DateTime.addMonths -1
+            in
+            DateTime.fromDate previousMonth.year previousMonth.month day.day
+
+        Next ->
+            let
+                nextMonth =
+                    DateTime.fromDate year month day.day
+                        |> DateTime.addMonths 1
+            in
+            DateTime.fromDate nextMonth.year nextMonth.month day.day
 
 
 generateCalendar : Date.Day -> Date.Month -> Int -> List (List Day)

--- a/src/DateTimePicker/Formatter.elm
+++ b/src/DateTimePicker/Formatter.elm
@@ -32,7 +32,7 @@ accessibilityDateFormatter dateTime =
 
 dateFormatter : DateTime.DateTime -> String
 dateFormatter dateTime =
-    toString (DateTime.monthToInt dateTime.month) ++ "/" ++ toString dateTime.day ++ "/" ++ toString dateTime.year
+    padWithZero (DateTime.monthToInt dateTime.month) ++ "/" ++ padWithZero dateTime.day ++ "/" ++ toString dateTime.year
 
 
 footerFormatter : DateTime.DateTime -> String
@@ -56,15 +56,15 @@ timeFormatter dateTime =
     let
         ( hourString, amPm ) =
             if dateTime.hour == 12 then
-                ( "12", "pm" )
+                ( "12", "PM" )
             else if dateTime.hour == 0 then
-                ( "12", "am" )
+                ( "12", "AM" )
             else if dateTime.hour > 12 then
-                ( toString (dateTime.hour % 12), "pm" )
+                ( padWithZero (dateTime.hour % 12), "PM" )
             else
-                ( toString dateTime.hour, "am" )
+                ( padWithZero dateTime.hour, "AM" )
     in
-    hourString ++ ":" ++ toString dateTime.minute ++ " " ++ amPm
+    hourString ++ ":" ++ padWithZero dateTime.minute ++ " " ++ amPm
 
 
 fullDayOfWeek : DateTime.DateTime -> String
@@ -130,3 +130,11 @@ fullMonth month =
 
         Date.Dec ->
             "December"
+
+
+padWithZero : Int -> String
+padWithZero input =
+    if input < 10 then
+        "0" ++ toString input
+    else
+        toString input

--- a/src/DateTimePicker/Formatter.elm
+++ b/src/DateTimePicker/Formatter.elm
@@ -56,13 +56,13 @@ timeFormatter dateTime =
     let
         ( hourString, amPm ) =
             if dateTime.hour == 12 then
-                ( "12", "PM" )
+                ( "12", "pm" )
             else if dateTime.hour == 0 then
-                ( "12", "AM" )
+                ( "12", "am" )
             else if dateTime.hour > 12 then
-                ( padWithZero (dateTime.hour % 12), "PM" )
+                ( padWithZero (dateTime.hour % 12), "pm" )
             else
-                ( padWithZero dateTime.hour, "AM" )
+                ( padWithZero dateTime.hour, "am" )
     in
     hourString ++ ":" ++ padWithZero dateTime.minute ++ " " ++ amPm
 

--- a/tests/FormatterTests.elm
+++ b/tests/FormatterTests.elm
@@ -36,7 +36,7 @@ dateFormatterTest =
         \() ->
             date
                 |> Formatter.dateFormatter
-                |> Expect.equal "9/10/2018"
+                |> Expect.equal "09/10/2018"
 
 
 footerFormatterTest : Test
@@ -54,7 +54,7 @@ dateTimeFormatterTest =
         \() ->
             date
                 |> Formatter.dateTimeFormatter
-                |> Expect.equal "9/10/2018 1:15 pm"
+                |> Expect.equal "09/10/2018 01:15 PM"
 
 
 timeFormatterTest : Test
@@ -63,4 +63,4 @@ timeFormatterTest =
         \() ->
             date
                 |> Formatter.timeFormatter
-                |> Expect.equal "1:15 pm"
+                |> Expect.equal "01:15 PM"

--- a/tests/FormatterTests.elm
+++ b/tests/FormatterTests.elm
@@ -54,7 +54,7 @@ dateTimeFormatterTest =
         \() ->
             date
                 |> Formatter.dateTimeFormatter
-                |> Expect.equal "09/10/2018 01:15 PM"
+                |> Expect.equal "09/10/2018 01:15 pm"
 
 
 timeFormatterTest : Test
@@ -63,4 +63,4 @@ timeFormatterTest =
         \() ->
             date
                 |> Formatter.timeFormatter
-                |> Expect.equal "01:15 PM"
+                |> Expect.equal "01:15 pm"


### PR DESCRIPTION
All of our use cases want the 0s. Also, I made a mistake where the aria-label values for the previous and next month days that fill in the drop down were incorrect. Our NRI specs caught it.